### PR TITLE
Remove the MediaFire download details

### DIFF
--- a/generic.html
+++ b/generic.html
@@ -30,7 +30,6 @@
                     <ul>
                         <li><a href="#intro" class="active">Introduction</a></li>
                         <li><a href="#install" class="">Installing</a></li>
-                        <li><a href="#mediafire" class="">Download from MediaFire</a></li>
                     </ul>
                 </nav>
 
@@ -80,16 +79,6 @@
                         <pre class="brush: bash">
                             composer create-project stupidlysimple/php myproject
                         </pre>
-                    </section>
-                    
-                    <!-- Content -->
-                    <section id="mediafire" class="main">
-                        <h2>Downloading StupidlySimple framework directly from MediaFire</h2>
-                        <p>If you do not want to download using Composer, you can download a zip file directly from MediaFire</p>
-                        <p>
-                            <!--<a href="https://www.mediafire.com/folder/lg53n0zz3nnsn/0.3.3" target="_blank" class="button special">Download Now</a>-->
-                            Outdated. Please use composer instead.
-                        </p>
                     </section>
 
                 </div>


### PR DESCRIPTION
As the MediaFire link is no longer used, is there a reason for keeping it?

As an alternative, you could link to the latest GitHub release:
https://github.com/stupidlysimple/php/releases/latest